### PR TITLE
Use `as_mut_ptr` instead of `as_ptr` to mutate string

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,17 @@ jobs:
 
     - name: Test
       run: cargo test --features serde
+
+  run-miri:
+    name: Run Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: nightly
+          components: miri
+
+      - run: cargo miri test
+        env:
+          MIRIFLAGS: "-Zmiri-strict-provenance"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl<const N: usize> StrBuf<N> {
     ///
     ///To safely modify the slice, user must guarantee to write valid UTF-8
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        slice::from_raw_parts_mut(self.as_ptr() as *mut u8, self.cursor as usize)
+        slice::from_raw_parts_mut(self.as_mut_ptr(), self.cursor as usize)
     }
 
     #[inline]
@@ -272,7 +272,7 @@ impl<const N: usize> StrBuf<N> {
     #[inline]
     ///Appends given string without any size checks
     pub unsafe fn push_str_unchecked(&mut self, text: &str) {
-        ptr::copy_nonoverlapping(text.as_ptr(), self.as_ptr().offset(self.cursor as isize) as *mut u8, text.len());
+        ptr::copy_nonoverlapping(text.as_ptr(), self.as_mut_ptr().offset(self.cursor as isize), text.len());
         self.set_len(self.cursor.saturating_add(text.len() as u8));
     }
 


### PR DESCRIPTION
Using `as_ptr` only gives read provenance since it goes through `&self`. `as_mut_ptr` goes through `&mut self` instead, which allows the pointer to be written to.

Also runs miri in CI to avoid these issues in the future.